### PR TITLE
feat: add gen client and use `CodecV2` to register fory as ser. layer

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/ayush00git/goth/grpc/goth"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	// connect to the gRPC server.
+	conn, err := grpc.NewClient(
+		"localhost:50051",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.ForceCodecV2(goth.CodecV2{}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
+	defer conn.Close()
+
+	// create the generated client
+	client := goth.NewGothServiceClient(conn)
+	resp, err := client.Signup(context.Background(), &goth.SignupRequest{
+		Email: "test1@gmail.com",
+		FullName: "tester",
+		Password: "tester123",
+	})
+	if err != nil {
+		log.Fatalf("Signup failed: %v", err)
+	}
+
+	fmt.Printf("User ID: %s\n", resp.UserId)
+	fmt.Printf("Email: %s\n", resp.Email)
+	fmt.Printf("Verified: %v\n", resp.EmailVerified)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,7 +34,9 @@ func main() {
 		log.Fatalf("failed listening at port: %v", err)
 	}
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(
+		grpc.ForceServerCodecV2(goth.CodecV2{}),
+	)
 	// register the gRPC server
 	goth.RegisterGothServiceServer(s, handlers.NewServer(db.Pool))
 	reflection.Register(s)	// reflection package helps grpcurl recognize the goth service definitions

--- a/internal/handlers/goth.go
+++ b/internal/handlers/goth.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/ayush00git/goth/grpc/goth"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // embeds the generated grpc server implementation for forward compatibility.
@@ -48,7 +48,8 @@ func (g *GothServer) Signup(ctx context.Context, req *goth.SignupRequest) (*goth
 	err = g.db.QueryRow(
 		ctx,
 		`INSERT INTO USERS (email, password_hash, full_name)
-		VALUES ($1, $2, $3)`,
+		VALUES ($1, $2, $3)
+		RETURNING id`,
 		email,
 		hashedPass,
 		fullName,


### PR DESCRIPTION
This PR adds the generated client to test server service stubs and registers fory codec `CodecV2` as the custom codec for using fory as the serialization layer instead of protobuf.