### PR TITLE
fix: stored access/refresh token to db on login

### DIFF
--- a/cmd/client/login.go
+++ b/cmd/client/login.go
@@ -8,15 +8,17 @@ import (
 )
 
 func TestLogin(c goth.GothServiceClient) {
-	_, err := c.Login(context.Background(), &goth.LoginRequest{
+	resp, err := c.Login(context.Background(), &goth.LoginRequest{
 		Email: "tester6412@gmail.com",
 		Password: "password123",
-		DeviceFingerprint: "web-chrome",
+		DeviceFingerprint: "web-chrome",	// might use uuid.NewString() to test how flow works for multiple devices
 	})
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Login Successfull\n")
-	// tokens
+	fmt.Printf("login successfull\n")
+	fmt.Printf("access_token: %s\n", resp.AccessToken)
+	fmt.Printf("refresh_token: %s\n", resp.RefreshToken)
+	// mfa-type
 }

--- a/cmd/client/logout.go
+++ b/cmd/client/logout.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ayush00git/goth/grpc/goth"
+)
+
+func TestLogout(c goth.GothServiceClient) {
+	resp, err := c.Logout(context.Background(), &goth.LogoutRequest{
+		RefreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY2E1MTg1ZDAtMWU0Ni00ZDdhLWFjMGItMmE4M2IyNTU5NGRlIiwiZW1haWwiOiJ0ZXN0ZXI2NDEyQGdtYWlsLmNvbSIsImRldmljZV9maW5nZXJwcmludCI6ImdvLWNsaWVudCIsInN1YiI6ImNhNTE4NWQwLTFlNDYtNGQ3YS1hYzBiLTJhODNiMjU1OTRkZSIsImV4cCI6MTc4MjkzMTU0MywiaWF0IjoxNzgyODQ1MTQzLCJqdGkiOiJmYzA5M2ZlYS03ZTZiLTRhMjItOGFhOC1lNTQ0MjA4ZmRlZjkifQ.Si88-ID05aUdY5vWSe_w1ZAul4SrZ1swUH_beZb0IR8",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("logout success!\n")
+	fmt.Printf("Success %t\n", resp.Success)
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -26,5 +26,6 @@ func main() {
 	// create the generated client
 	client := goth.NewGothServiceClient(conn)
 	// TestSignup(client)
-	TestLogin(client)
+	// TestLogin(client)
+	TestLogout(client)
 }

--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -4,10 +4,19 @@ import (
 	"context"
 
 	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/services"
+	"github.com/jackc/pgx/v5"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// LoginReqBody
+type RequestedUser struct {
+	id			string
+	email		string
+	password	string
+}
 
 func (g *GothServer) Login(ctx context.Context, req *goth.LoginRequest) (*goth.LoginResponse, error) {
 	// inputs
@@ -27,8 +36,11 @@ func (g *GothServer) Login(ctx context.Context, req *goth.LoginRequest) (*goth.L
 		FROM users
 		WHERE $1 = email`, email,
 	).Scan(&user.id, &user.email, &user.password)
+	if err == pgx.ErrNoRows {
+		return nil, status.Error(codes.Unauthenticated, "invalid credentials")
+	}
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "user not found")
+		return nil, status.Error(codes.Internal, "database error")
 	}
 
 	// match the password
@@ -37,10 +49,35 @@ func (g *GothServer) Login(ctx context.Context, req *goth.LoginRequest) (*goth.L
 		return nil, status.Error(codes.Unauthenticated, "credentials do not match.")
 	}
 
+	// generate an access token on login
+	accessToken, err := services.GenerateAccessToken(user.id, user.email)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed generating an access token")
+	}
+
+	// generate a refresh token
+	refreshToken, jti, err := services.GenerateRefreshToken(user.id, user.email, "go-client")
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed generating a refresh token")
+	}
+
+	// save jti to the db table
+	_, err = g.db.Exec(
+		ctx,
+		`INSERT INTO REFRESH_TOKENS (user_id, jti, device_fingerprint)
+		VALUES ($1, $2, $3)`,
+		user.id,
+		jti,
+		"go-client",	// for testing
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to store refresh token to database")
+	}
+
 	// just placeholders for now
 	return &goth.LoginResponse{
-		AccessToken: "need-to-be-set",
-		RefreshToken: "need-to-be-set",
+		AccessToken: accessToken,
+		RefreshToken: refreshToken,
 		MfaRequired: true,
 		MfaSessionToken: "need-to-be-set",
 		MfaType: 0,

--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -34,7 +34,7 @@ func (g *GothServer) Login(ctx context.Context, req *goth.LoginRequest) (*goth.L
 		ctx,
 		`SELECT id, email, password_hash
 		FROM users
-		WHERE $1 = email`, email,
+		WHERE email = $1`, email,
 	).Scan(&user.id, &user.email, &user.password)
 	if err == pgx.ErrNoRows {
 		return nil, status.Error(codes.Unauthenticated, "invalid credentials")

--- a/internal/handlers/logout.go
+++ b/internal/handlers/logout.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/services"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (g *GothServer) Logout(ctx context.Context, req *goth.LogoutRequest) (*goth.LogoutResponse, error) {
+	claims, err := services.ValidateRefreshToken(req.RefreshToken)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, "unverified refresh token")
+	}
+	// revoke the refresh token
+	tag, err := g.db.Exec(
+		ctx,
+		`UPDATE REFRESH_TOKENS
+		SET revoked = TRUE
+		WHERE jti = $1`,
+		claims.ID,		// claims.ID = jti
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed revoking refresh token")
+	}
+	if tag.RowsAffected() == 0 {
+    	return nil, status.Error(codes.NotFound, "session not found")
+	}
+
+	return &goth.LogoutResponse{Success: true}, nil
+}

--- a/internal/handlers/signup.go
+++ b/internal/handlers/signup.go
@@ -25,14 +25,6 @@ func NewServer(db *pgxpool.Pool) *GothServer {
 	}
 }
 
-// LoginReqBody
-type RequestedUser struct {
-	id			string
-	email		string
-	fullName	string
-	password	string
-}
-
 func (g *GothServer) Signup(ctx context.Context, req *goth.SignupRequest) (*goth.SignupResponse, error) {
 	// inputs from request body
 	email := req.Email

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -136,18 +136,21 @@ func RefreshAccessToken(refreshToken string) (string, error) {
 
 // Helper function which validates the refresh token, just required using
 // logout to revoke the current stored refresh token
-func ValidateRefreshToken(refreshTokenString string) (jti string, err error) {
+func ValidateRefreshToken(refreshTokenString string) (*Claims, error) {
 	secretKey := helpers.GetEnvVar("REFRESH_TOKEN_SECRET")
 	refreshToken, err := jwt.ParseWithClaims(refreshTokenString, &Claims{},
 		func(refreshToken *jwt.Token) (interface{}, error) {
 			return []byte(secretKey), nil
 		},
 	)
+	if err != nil {
+		return nil, err
+	}	
 
 	claims, ok := refreshToken.Claims.(*Claims)
 	if !ok || !refreshToken.Valid {
-		return "", errors.New("Invalid token")
+		return nil, errors.New("Invalid token")
 	}
 
-	return claims.ID, nil	// claims.ID = jti
+	return claims, nil
 }

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -94,6 +94,8 @@ func GenerateRefreshToken(userId, email, fingerprint string) (tokenString string
 	return tokenString, jti, nil
 }
 
+// Helper function which generates a new access token once the old one get expires,
+// it get its claims by validating the refresh token stored in the database.
 func RefreshAccessToken(refreshToken string) (string, error) {
 	refreshSecret := helpers.GetEnvVar("REFRESH_TOKEN_SECRET")
 	accessSecret := helpers.GetEnvVar("ACCESS_TOKEN_SECRET")
@@ -130,4 +132,22 @@ func RefreshAccessToken(refreshToken string) (string, error) {
 		return "", err
 	}
 	return accessTokenString, nil
+}
+
+// Helper function which validates the refresh token, just required using
+// logout to revoke the current stored refresh token
+func ValidateRefreshToken(refreshTokenString string) (jti string, err error) {
+	secretKey := helpers.GetEnvVar("REFRESH_TOKEN_SECRET")
+	refreshToken, err := jwt.ParseWithClaims(refreshTokenString, &Claims{},
+		func(refreshToken *jwt.Token) (interface{}, error) {
+			return []byte(secretKey), nil
+		},
+	)
+
+	claims, ok := refreshToken.Claims.(*Claims)
+	if !ok || !refreshToken.Valid {
+		return "", errors.New("Invalid token")
+	}
+
+	return claims.ID, nil	// claims.ID = jti
 }


### PR DESCRIPTION
Closes #34 
This PR updates the login flow adding the access token generation and refresh token generation + store to db.

Response structure - 
```bash
-[ RECORD 3 ]------+-------------------------------------
id                 | 1033d13f-8bd1-48f3-be55-6d4a0a39467e
user_id            | ca5185d0-1e46-4d7a-ac0b-2a83b25594de
jti                | fc093fea-7e6b-4a22-8aa8-e544208fdef9
expires_at         | 2026-07-02 00:15:43.682774+05:30
revoked            | t
device_fingerprint | go-client
created_at         | 2026-07-01 00:15:43.682774+05:30

```