### PR TITLE
feat: implement RefreshToken rpc method for server/client

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -27,5 +27,6 @@ func main() {
 	client := goth.NewGothServiceClient(conn)
 	// TestSignup(client)
 	// TestLogin(client)
-	TestLogout(client)
+	// TestLogout(client)
+	TestRefreshToken(client)
 }

--- a/cmd/client/refresh_token.go
+++ b/cmd/client/refresh_token.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ayush00git/goth/grpc/goth"
+)
+
+func TestRefreshToken(c goth.GothServiceClient) {
+	resp, err := c.RefreshToken(context.Background(), &goth.RefreshTokenRequest{
+		RefreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY2E1MTg1ZDAtMWU0Ni00ZDdhLWFjMGItMmE4M2IyNTU5NGRlIiwiZW1haWwiOiJ0ZXN0ZXI2NDEyQGdtYWlsLmNvbSIsImRldmljZV9maW5nZXJwcmludCI6ImdvLWNsaWVudCIsInN1YiI6ImNhNTE4NWQwLTFlNDYtNGQ3YS1hYzBiLTJhODNiMjU1OTRkZSIsImV4cCI6MTc4Mjk5NTAxOSwiaWF0IjoxNzgyOTA4NjE5LCJqdGkiOiJlODgzYTEyMC1jYjViLTQyZDItODE5ZC0zNTM2NzY1NTNkNTMifQ.o0ffs4bkOrE_Tfa9Y9Er96Vimt1FJNlx1IO7RzsSm9w",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("refresh token revoked!\n")
+	fmt.Printf("refresh token: %s\n", resp.RefreshToken)
+	fmt.Printf("access token: %s\n", resp.AccessToken)
+}

--- a/internal/handlers/refresh_token.go
+++ b/internal/handlers/refresh_token.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/services"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// rpc handler which implements the handler logic for rpc method RefreshToken, accepts a
+// refresh token and rotates the refresh token and returns an access token
+func (g *GothServer) RefreshToken(ctx context.Context, req *goth.RefreshTokenRequest) (*goth.RefreshTokenResponse, error) {
+	refreshTokenString := req.RefreshToken
+	// parse the incoming the refresh token string
+	claims, err := services.ValidateRefreshToken(refreshTokenString)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, "unauthenticated access")
+	}
+
+	// revoke the old refresh token
+	oldJti := claims.ID		// registered claims `ID` is identification for the jwt
+
+	// rotate the refresh token for the user
+	// start the query transaction
+	tx, err := g.db.Begin(ctx)
+	if err != nil{
+		return nil, status.Error(codes.Internal, "failed starting database transaction")
+	}
+	defer tx.Rollback(ctx)
+	// revoke the old refresh token
+	tag, err := tx.Exec(
+		ctx,
+		`UPDATE refresh_tokens
+		SET revoked = true
+		WHERE jti = $1 AND revoked = false`, // revoked = false handles the race conditions
+		oldJti,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed revoking token")
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, status.Error(codes.Unauthenticated, "refresh token is invalid or just got revoked")
+	}
+
+	// generate a new refresh token and create a new row using this newJti
+	refreshTokenString, newJti, err := services.GenerateRefreshToken(claims.UserID, claims.Email, claims.DeviceFingerprint)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed generating refresh token")
+	}
+
+	// insert a new refresh token into database for this user
+	_, err = tx.Exec(
+		ctx,
+		`INSERT INTO refresh_tokens (user_id, jti, device_fingerprint)
+		VALUES ($1, $2, $3)
+		`,
+		claims.UserID,
+		newJti,
+		claims.DeviceFingerprint,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed inserting to database")
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, status.Error(codes.Internal, "failed updating database")
+	}
+	
+	// generate an access token unconditionally
+	accessTokenString, err := services.GenerateAccessToken(claims.UserID, claims.Email)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed generating access token")
+	}
+
+	return &goth.RefreshTokenResponse{
+		AccessToken: accessTokenString,
+		RefreshToken: refreshTokenString,
+	}, nil
+}

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// embeds the generated grpc server implementation for forward compatibility.
+// shared psql connection pools to be used by rpc handlers.
+type GothServer struct {
+	goth.UnimplementedGothServiceServer
+	db *pgxpool.Pool
+}
+
+// NewServer creates a new gRPC sever with its required dependencies.
+func NewServer(db *pgxpool.Pool) *GothServer {
+	return &GothServer{
+		db: db,
+	}
+}

--- a/internal/handlers/signup.go
+++ b/internal/handlers/signup.go
@@ -4,26 +4,10 @@ import (
 	"context"
 
 	"github.com/ayush00git/goth/grpc/goth"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-// embeds the generated grpc server implementation for forward compatibility.
-// shared psql connection pools to be used by rpc handlers.
-type GothServer struct {
-	goth.UnimplementedGothServiceServer
-	db *pgxpool.Pool
-}
-
-// NewServer creates a new gRPC sever with its required dependencies.
-func NewServer(db *pgxpool.Pool) *GothServer {
-	return &GothServer{
-		db: db,
-	}
-}
 
 func (g *GothServer) Signup(ctx context.Context, req *goth.SignupRequest) (*goth.SignupResponse, error) {
 	// inputs from request body


### PR DESCRIPTION
This PR implements the server api -
```go
RefreshToken(ctx context.Context, in *RefreshTokenRequest, opts ...grpc.CallOption) (*RefreshTokenResponse, error)
```
in `handlers/` which accepts a `refresh_token` string from the request object and sends response - a new refresh token, revoking the old one and an access token.

- Client API is also implemented (`cmd/client/refresh_token.go`) for testing the server api implementation.