### PR TITLE
feat: implement auth interceptor and claims helper

### DIFF
--- a/internal/interceptors/auth.go
+++ b/internal/interceptors/auth.go
@@ -1,0 +1,46 @@
+package interceptors
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ayush00git/goth/internal/services"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func AuthInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	// read incoming metadata
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "missing metadata")
+	}
+
+	// read authorization header
+	values := md.Get("authorization")
+	if len(values) == 0 {
+		return nil, status.Error(codes.Unauthenticated, "authorization header missing")
+	}
+
+	authHeader := values[0]
+
+	// must have a prefix "Bearer"
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return nil, status.Error(codes.Unauthenticated, "invalid authorization header")
+	}
+
+	accessToken := strings.TrimPrefix(authHeader, "Bearer ")
+
+	// validate the access token
+	claims, err := services.ValidateAccessToken(accessToken)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, "invalid access token")
+	}
+
+	// store the claims in context
+	ctx = context.WithValue(ctx, UserContextKeys{}, claims)
+
+	return handler(ctx, req)
+}

--- a/internal/interceptors/context.go
+++ b/internal/interceptors/context.go
@@ -1,0 +1,17 @@
+package interceptors
+
+import (
+	"context"
+
+	"github.com/ayush00git/goth/internal/services"
+)
+
+// to avoid plain strings storing the context keys
+type UserContextKeys struct {}
+
+// helper function to use instead of asserting type
+// every time for UserContextKeys{}
+func GetClaims(ctx context.Context) (*services.Claims, bool) {
+	claims, ok := ctx.Value(UserContextKeys{}).(*services.Claims)
+	return claims, ok
+}


### PR DESCRIPTION
References #35 
- This PR adds an authentication interceptor (`internal/interceptors/auth.go`) which reads client's metadata for access token (most commonly the authorization bearer token) and validates the access token.
- Also adds a `GetClaims` helper function which returns the `UserContextKeys` type asserted, so there's no need to type assert the `services.Claims` struct everytime in rpc handlers which getting the context keys.