### PR TITLE
feat: add logging/recovery unary interceptors to server

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -25,8 +25,8 @@ func main() {
 
 	// create the generated client
 	client := goth.NewGothServiceClient(conn)
-	// TestSignup(client)
+	TestSignup(client)
 	// TestLogin(client)
 	// TestLogout(client)
-	TestRefreshToken(client)
+	// TestRefreshToken(client)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ayush00git/goth/internal/db"
 	"github.com/ayush00git/goth/internal/handlers"
 	"github.com/ayush00git/goth/internal/helpers"
+	"github.com/ayush00git/goth/internal/interceptors"
 	"github.com/joho/godotenv"
 
 	"google.golang.org/grpc"
@@ -46,6 +47,11 @@ func main() {
 	// default protobuf
 	s := grpc.NewServer(
 		grpc.ForceServerCodecV2(goth.CodecV2{}),
+		grpc.ChainUnaryInterceptor(
+			interceptors.RecoveryInterceptor,
+			interceptors.LoggingInterceptor,
+			interceptors.AuthInterceptor,
+		),
 	)
 	
 	// register the gRPC server

--- a/internal/interceptors/auth.go
+++ b/internal/interceptors/auth.go
@@ -12,6 +12,16 @@ import (
 )
 
 func AuthInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+
+	// bypass AuthInterceptor for these public rpcs
+	switch info.FullMethod {
+		case "/goth.GothService/Login",
+			"goth.GothService/Signup",
+			"goth.GothService/SendOTP",
+			"goth.GothService/VerifyOTP":
+			return handler(ctx, req)
+	}
+
 	// read incoming metadata
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {

--- a/internal/interceptors/auth.go
+++ b/internal/interceptors/auth.go
@@ -16,9 +16,9 @@ func AuthInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, h
 	// bypass AuthInterceptor for these public rpcs
 	switch info.FullMethod {
 		case "/goth.GothService/Login",
-			"goth.GothService/Signup",
-			"goth.GothService/SendOTP",
-			"goth.GothService/VerifyOTP":
+			"/goth.GothService/Signup",
+			"/goth.GothService/SendOTP",
+			"/goth.GothService/VerifyOTP":
 			return handler(ctx, req)
 	}
 

--- a/internal/interceptors/logging.go
+++ b/internal/interceptors/logging.go
@@ -1,0 +1,27 @@
+package interceptors
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// LoggingInterceptor writes a log entry for every unary RPC request and response.
+// It logs the method name, request duration, and whether the call returned an error.
+func LoggingInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	start := time.Now()
+	log.Printf("gRPC request started: method=%s", info.FullMethod)
+
+	resp, err := handler(ctx, req)
+	duration := time.Since(start)
+
+	if err != nil {
+		log.Printf("gRPC request finished: method=%s duration=%s error=%v", info.FullMethod, duration, err)
+	} else {
+		log.Printf("gRPC request finished: method=%s duration=%s response=%T", info.FullMethod, duration, resp)
+	}
+
+	return resp, err
+}

--- a/internal/interceptors/recovery.go
+++ b/internal/interceptors/recovery.go
@@ -1,0 +1,24 @@
+package interceptors
+
+import (
+	"context"
+	"log"
+	"runtime/debug"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RecoveryInterceptor is a unary gRPC interceptor that protects the server
+// from panic crashes by recovering and returning an internal error.
+func RecoveryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("panic recovered in method %s: %v\n%s", info.FullMethod, rec, string(debug.Stack()))
+			err = status.Error(codes.Internal, "internal server error")
+		}
+	}()
+
+	return handler(ctx, req)
+}


### PR DESCRIPTION
References and Closes #35 
- This PR adds the logging and recovery unary interceptors and registers them to the `grpc.NewServer` instance.
- Also bypass the `AuthInterceptor` for public RPCs.

Results - 
```bash
❯ go run cmd/server/main.go
2026/07/02 22:20:49 connected to database
2026/07/02 22:20:49 Goth server running on port :50051
2026/07/02 22:20:55 gRPC request started: method=/goth.GothService/Signup
2026/07/02 22:20:55 gRPC request finished: method=/goth.GothService/Signup duration=84.808433ms response=*goth.SignupResponse
2026/07/02 22:23:08 gRPC request started: method=/goth.GothService/Login
2026/07/02 22:23:08 gRPC request finished: method=/goth.GothService/Login duration=87.057223ms response=*goth.LoginResponse
2026/07/02 22:23:26 gRPC request started: method=/goth.GothService/Login
2026/07/02 22:23:26 gRPC request finished: method=/goth.GothService/Login duration=70.4006ms error=rpc error: code = Unauthenticated desc = credentials do not match.
```