### PR TITLE
feat: implement mfa_type = totp for mfa

### DIFF
--- a/cmd/client/test/enable_mfa.go
+++ b/cmd/client/test/enable_mfa.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ayush00git/goth/grpc/goth"
+)
+
+func TestEnableMFA(c goth.GothServiceClient) {
+	resp, err := c.EnableMFA(context.Background(), &goth.EnableMFARequest{
+		MfaType: 1,
+	})
+	if err != nil {
+		panic((err))
+	}
+
+	fmt.Print("MFA Enabled\n")
+	fmt.Printf("totp_secret: %s", resp.TotpSecret)
+	fmt.Printf("totp_QrUrl: %s", resp.TotpQrUrl)
+	// otp expiry for `mfa_type = 2`
+}

--- a/cmd/client/test/main.go
+++ b/cmd/client/test/main.go
@@ -25,8 +25,9 @@ func main() {
 
 	// create the generated client
 	client := goth.NewGothServiceClient(conn)
-	TestSignup(client)
+	// TestSignup(client)
 	// TestLogin(client)
 	// TestLogout(client)
 	// TestRefreshToken(client)
+	TestEnableMFA(client)
 }

--- a/internal/handlers/enable_mfa.go
+++ b/internal/handlers/enable_mfa.go
@@ -4,6 +4,9 @@ import (
 	"context"
 
 	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/helpers"
+	"github.com/ayush00git/goth/internal/interceptors"
+	"github.com/ayush00git/goth/internal/services"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -16,48 +19,52 @@ func (g *GothServer) EnableMFA(ctx context.Context, req *goth.EnableMFARequest) 
 	//			= 1 : TOTP
 	// 			= 2 : EmailOTP
 	mfa_type := req.MfaType
-	userID := req.UserId
 
+	// userID := req.UserId		// UserId does comes from request body, but can't be trusted, fetch it from UserContextKeys{} instead
+	claims, ok := interceptors.GetClaims(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
+	}
+	userID := claims.UserID
+
+	// start the databse transaction
 	tx, err := g.db.Begin(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "error starting database transaction")
 	}
 	// register this into a new row in mfa_secrets table
 	defer tx.Rollback(ctx)
+
+	// generate the totp_secret (random 32 bytes base-32 encoded string)
+	totp_secret, err := helpers.GenerateTOTPSecret()
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed generating totp_secret")
+	}
+
 	_, err = tx.Exec(
 		ctx,
 		`INSERT INTO mfa_secrets (user_id, totp_secret, mfa_type)
 		VALUES ($1, $2, $3)`,
 		userID,
-		"totp_secret",
+		totp_secret,
 		mfa_type,
 	)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed inserting to database")
 	}
 	
-	// register the same mfa_type in the users table
-	tag, err := tx.Exec(
-		ctx,
-		`UPDATE users
-		SET mfa_type = $1
-		WHERE id = $2`,
-		mfa_type,
-		userID,
-	)
-	if err != nil {
-		return nil, status.Error(codes.Internal, "failed updating mfa_type to users")
-	}
-	if tag.RowsAffected() == 0 {
-		return nil, status.Error(codes.Unauthenticated, "user not found")
-	}
 	// commit the transaction
 	if err := tx.Commit(ctx); err != nil {
 		return nil, status.Error(codes.Internal, "failed committing the database transaction")
 	}
 
+	// generate the totp QR URL to be passed to the authenticator app
+	QrURL := services.GenerateTOTPQRURL(claims.Email, totp_secret)
+
 	return &goth.EnableMFAResponse{
 		Success: true,
-		TotpSecret: 
+		TotpSecret: totp_secret,
+		TotpQrUrl: QrURL,
+		OtpExpiresIn: 0,
 	}, nil
 }

--- a/internal/handlers/enable_mfa.go
+++ b/internal/handlers/enable_mfa.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/ayush00git/goth/grpc/goth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// EnableMFA allows client to enable multi-factor authentication for their
+// accounts. It accepts the mfa_type and activates the same for the user.
+func (g *GothServer) EnableMFA(ctx context.Context, req *goth.EnableMFARequest) (*goth.EnableMFAResponse, error) {
+	// client will send MFA type to be enabled for the user
+	// mfa_type = 0 : None
+	//			= 1 : TOTP
+	// 			= 2 : EmailOTP
+	mfa_type := req.MfaType
+	userID := req.UserId
+
+	tx, err := g.db.Begin(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "error starting database transaction")
+	}
+	// register this into a new row in mfa_secrets table
+	defer tx.Rollback(ctx)
+	_, err = tx.Exec(
+		ctx,
+		`INSERT INTO mfa_secrets (user_id, totp_secret, mfa_type)
+		VALUES ($1, $2, $3)`,
+		userID,
+		"totp_secret",
+		mfa_type,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed inserting to database")
+	}
+	
+	// register the same mfa_type in the users table
+	tag, err := tx.Exec(
+		ctx,
+		`UPDATE users
+		SET mfa_type = $1
+		WHERE id = $2`,
+		mfa_type,
+		userID,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed updating mfa_type to users")
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, status.Error(codes.Unauthenticated, "user not found")
+	}
+	// commit the transaction
+	if err := tx.Commit(ctx); err != nil {
+		return nil, status.Error(codes.Internal, "failed committing the database transaction")
+	}
+
+	return &goth.EnableMFAResponse{
+		Success: true,
+		TotpSecret: 
+	}, nil
+}

--- a/internal/helpers/totp_secret.go
+++ b/internal/helpers/totp_secret.go
@@ -1,0 +1,19 @@
+package helpers
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+)
+
+// GenerateTOTPSecret generates a random 32 bytes string
+// base32 encode it and returns it as the totp_secret.
+func GenerateTOTPSecret() (string, error) {
+	secretBytes := make([]byte, 32)
+
+	if _, err := rand.Read(secretBytes); err != nil {
+		return "", err
+	}
+
+	encodedSecret := base32.StdEncoding.EncodeToString(secretBytes)
+	return encodedSecret, nil
+}

--- a/internal/services/totp_qr.go
+++ b/internal/services/totp_qr.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func GenerateTOTPQRURL(email, totp_secret string) string {
+	return fmt.Sprintf("otpauth://totp/goth:%s?secret=%s&issuer=goth",
+		url.QueryEscape(email),
+		totp_secret,
+	)
+}

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -23,7 +23,7 @@ CREATE TABLE refresh_tokens (
 
 CREATE TABLE mfa_secrets (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id             UUID REFERENCES users(id),
+    user_id             UUID UNIQUE REFERENCES users(id),   -- only one mfa_secret per user
     totp_secret         VARCHAR(255),
     mfa_type            SMALLINT DEFAULT 0,
     is_verified         BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
References #42 
- This PR implements the `EnableMFA` rpc method, with accepting the mfa type and userId from the client, the server registers the mfa_secrets for the user and the user's preferred mfa type in its table.
- TotpSecret: (random string of 32 bytes + Base32 encoded).
- HMAC-SHA1(TotpSecret + unix time period in range (30 seconds)) - 6 digit token which is shared between the server and the client's authenticator app.

### The flow - 
1. If `mfa_type = 1`. The client has opted for a TOTP (Time-based One Time Password) typa multi factor authentication.
2. Server generates a random 32-bytes string, Base32 encode it, and stores it in `mfa_secrets` table as `totp_secret`, this `totp_secret` is shared by a QR to the client, so that the Authenticator app gets the totp_secret.
3. In particular ranges of time (30 seconds), both the server and client's authenticator app generates a same random string (truncated to 6 bytes)  = HMAC-SHA1(totp_secret + unix_time). If the 6 digits matches, the user is authenticated!.