### PR TITLE
refactor: remove untrusted payloads from rpc requests

### DIFF
--- a/grpc/goth/goth.go
+++ b/grpc/goth/goth.go
@@ -165,8 +165,7 @@ func (m *RefreshTokenResponse) FromBytes(data []byte) error {
 
 // Type ID 108 is specified manually.
 type EnableMFARequest struct {
-	UserId string `fory:"id=1"`
-	MfaType MFAType `fory:"id=2"`
+	MfaType MFAType `fory:"id=1"`
 }
 
 func (m *EnableMFARequest) ToBytes() ([]byte, error) {
@@ -197,7 +196,6 @@ func (m *EnableMFAResponse) FromBytes(data []byte) error {
 type VerifyMFARequest struct {
 	MfaSessionToken string `fory:"id=1"`
 	Code string `fory:"id=2"`
-	MfaType MFAType `fory:"id=3"`
 }
 
 func (m *VerifyMFARequest) ToBytes() ([]byte, error) {
@@ -225,8 +223,7 @@ func (m *VerifyMFAResponse) FromBytes(data []byte) error {
 
 // Type ID 112 is specified manually.
 type DisableMFARequest struct {
-	UserId string `fory:"id=1"`
-	Code string `fory:"id=2"`
+	Code string `fory:"id=1"`
 }
 
 func (m *DisableMFARequest) ToBytes() ([]byte, error) {

--- a/schema/goth.fdl
+++ b/schema/goth.fdl
@@ -63,8 +63,7 @@ message RefreshTokenResponse [id=107] {
 }
 
 message EnableMFARequest [id=108] {
-    string user_id = 1;
-    MFAType mfa_type = 2;
+    MFAType mfa_type = 1;
 }
 
 message EnableMFAResponse [id=109] {
@@ -77,7 +76,6 @@ message EnableMFAResponse [id=109] {
 message VerifyMFARequest [id=110] {
     string mfa_session_token = 1;
     string code = 2;
-    MFAType mfa_type = 3;
 }
 
 message VerifyMFAResponse [id=111] {
@@ -87,8 +85,7 @@ message VerifyMFAResponse [id=111] {
 }
 
 message DisableMFARequest [id=112] {
-    string user_id = 1;
-    string code = 2;
+    string code = 1;
 }
 
 message DisableMFAResponse [id=113] {


### PR DESCRIPTION
Closes #43 
This PR removes the untrusted client sent data, the `AuthInterceptor` never accepts the `UserId` to be sent from an authenticated user as the user may send a malformed one and can modify the data for some other user. The user's identification could be easily fetched from the metadata stored in the `UserContextKeys{}`.

Also remove the mfa_type request data while verifying the `mfa_type`.