### PR TITLE
fix: attach pre-defined metadata to `EnableMFA` rpc

### DIFF
--- a/cmd/client/test/enable_mfa.go
+++ b/cmd/client/test/enable_mfa.go
@@ -5,10 +5,18 @@ import (
 	"fmt"
 
 	"github.com/ayush00git/goth/grpc/goth"
+	"google.golang.org/grpc/metadata"
 )
 
-func TestEnableMFA(c goth.GothServiceClient) {
-	resp, err := c.EnableMFA(context.Background(), &goth.EnableMFARequest{
+func TestEnableMFA(c goth.GothServiceClient, accessToken string) {
+    md := metadata.Pairs(
+        "authorization",
+        "Bearer "+accessToken,
+    )
+
+    ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+	resp, err := c.EnableMFA(ctx, &goth.EnableMFARequest{
 		MfaType: 1,
 	})
 	if err != nil {
@@ -16,7 +24,7 @@ func TestEnableMFA(c goth.GothServiceClient) {
 	}
 
 	fmt.Print("MFA Enabled\n")
-	fmt.Printf("totp_secret: %s", resp.TotpSecret)
-	fmt.Printf("totp_QrUrl: %s", resp.TotpQrUrl)
+	fmt.Printf("totp_secret: %s\n", resp.TotpSecret)
+	fmt.Printf("totp_QrUrl: %s\n", resp.TotpQrUrl)
 	// otp expiry for `mfa_type = 2`
 }

--- a/cmd/client/test/main.go
+++ b/cmd/client/test/main.go
@@ -10,6 +10,9 @@ import (
 )
 
 func main() {
+	// metadata to test the gRPC server without an actual gRPC client
+	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY2E1MTg1ZDAtMWU0Ni00ZDdhLWFjMGItMmE4M2IyNTU5NGRlIiwiZW1haWwiOiJ0ZXN0ZXI2NDEyQGdtYWlsLmNvbSIsInN1YiI6ImNhNTE4NWQwLTFlNDYtNGQ3YS1hYzBiLTJhODNiMjU1OTRkZSIsImV4cCI6MTc4MzE3NjEwNiwiaWF0IjoxNzgzMTc1MjA2fQ.5jf1GxA6YIitMnlvI7hw-DzpcSCcMSA7hH94zvLjRio"
+
 	// connect to the gRPC server.
 	conn, err := grpc.NewClient(
 		"localhost:50051",
@@ -29,5 +32,5 @@ func main() {
 	// TestLogin(client)
 	// TestLogout(client)
 	// TestRefreshToken(client)
-	TestEnableMFA(client)
+	TestEnableMFA(client, accessToken)
 }

--- a/internal/handlers/enable_mfa.go
+++ b/internal/handlers/enable_mfa.go
@@ -19,8 +19,8 @@ func (g *GothServer) EnableMFA(ctx context.Context, req *goth.EnableMFARequest) 
 	//			= 1 : TOTP
 	// 			= 2 : EmailOTP
 	mfa_type := req.MfaType
-
-	// userID := req.UserId		// UserId does comes from request body, but can't be trusted, fetch it from UserContextKeys{} instead
+	
+	// get userID from the metadata stored in UserContextKeys{}
 	claims, ok := interceptors.GetClaims(ctx)
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, "user not authenticated")

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -51,7 +51,7 @@ func ValidateAccessToken(tokenString string) (*Claims, error) {
 	// parse the jwt token string.
 	token, err := jwt.ParseWithClaims(tokenString, &Claims{},
 		func(token *jwt.Token) (interface{}, error) {
-			return secretKey, nil
+			return []byte(secretKey), nil
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Closes #42 

This PR feeds a pre-defined metadata to `EnableMFA` rpc method for testing.