### PR TITLE
feat: implement `DisableMFA` rpc handler for all mfa_type

### DIFF
--- a/client/cli/disable_mfa.go
+++ b/client/cli/disable_mfa.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
+)
+
+var disableMFACmd = &cobra.Command{
+	Use:   "disable-mfa",
+	Short: "Disable MFA for the authenticated user",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		accessToken, _ := cmd.Flags().GetString("access-token")
+		code, _ := cmd.Flags().GetString("code")
+
+		client, conn, err := grpcClient()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		md := metadata.Pairs("authorization", "Bearer "+accessToken)
+		ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+		resp, err := client.DisableMFA(ctx, &goth.DisableMFARequest{
+			Code: code,
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("MFA Disabled")
+		fmt.Printf("Success:      %t\n", resp.Success)
+		return nil
+	},
+}
+
+func init() {
+	disableMFACmd.Flags().String("access-token", "", "Bearer access token (required)")
+	disableMFACmd.Flags().String("code", "", "TOTP or email OTP code (required)")
+
+	_ = disableMFACmd.MarkFlagRequired("access-token")
+	_ = disableMFACmd.MarkFlagRequired("code")
+
+	rootCmd.AddCommand(disableMFACmd)
+}

--- a/internal/handlers/disable_mfa.go
+++ b/internal/handlers/disable_mfa.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/interceptors"
+	"github.com/pquerna/otp/totp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (g *GothServer) DisableMFA(ctx context.Context, req *goth.DisableMFARequest) (*goth.DisableMFAResponse, error) {
+	code := req.Code
+	// access tokens would be authenticated by the auth interceptor
+	claims, ok := interceptors.GetClaims(ctx)
+	if !ok {
+		return nil, status.Error(codes.Internal, "failed parsing the claims")
+	}
+
+	userID := claims.UserID
+
+	var initials Creds
+	err := g.db.QueryRow(
+		ctx,
+		`SELECT mfa_type, totp_secret
+		FROM mfa_secrets
+		WHERE id = $1`,
+		userID,
+	).Scan(&initials.MfaType, &initials.TotpSecret)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to read the database")
+	}
+
+	switch initials.MfaType {
+		case 1:
+			// validate the client entered TOTP by generating it on server-side
+			// via the same totp_secret.
+			valid := totp.Validate(code, *initials.TotpSecret)	// computes the check by the RPC 6238 algorithm
+			if !valid {
+				return nil, status.Error(codes.PermissionDenied, "invalid code")
+			}
+			
+			// Delete the mfa_secrets for this user
+			_, err := g.db.Exec(
+				ctx,
+				`DELETE FROM mfa_secrets
+				WHERE user_id = $1`,
+				userID,
+			)
+			if err != nil {
+				return nil, status.Error(codes.Internal, "failed to delete the mfa_secrets")
+			}
+		
+		case 2:
+			
+	}
+
+	return &goth.DisableMFAResponse{
+		Success: true,
+	}, nil
+}

--- a/internal/handlers/disable_mfa.go
+++ b/internal/handlers/disable_mfa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ayush00git/goth/grpc/goth"
+	"github.com/ayush00git/goth/internal/helpers"
 	"github.com/ayush00git/goth/internal/interceptors"
 	"github.com/pquerna/otp/totp"
 	"google.golang.org/grpc/codes"
@@ -41,7 +42,7 @@ func (g *GothServer) DisableMFA(ctx context.Context, req *goth.DisableMFARequest
 				return nil, status.Error(codes.PermissionDenied, "invalid code")
 			}
 			
-			// Delete the mfa_secrets for this user
+			// Delete mfa_secrets for this user
 			_, err := g.db.Exec(
 				ctx,
 				`DELETE FROM mfa_secrets
@@ -53,8 +54,34 @@ func (g *GothServer) DisableMFA(ctx context.Context, req *goth.DisableMFARequest
 			}
 		
 		case 2:
-			
-	}
+			// match the otp with the one stored in redis.
+			hashCode, err := g.rdb.Get(
+				ctx,
+				"mfa:email_otp:" + userID,
+			).Result()
+			if err != nil {
+				return nil, status.Error(codes.NotFound, "code may be expired")
+			}
+
+			err = helpers.ValidateHash(hashCode, code)
+			if err != nil {
+				return nil, status.Error(codes.Unauthenticated, "invalid code")
+			}
+
+			// Delete mfa_secrets for this user
+			_, err = g.db.Exec(
+				ctx,
+				`DELETE FROM mfa_secrets
+				WHERE user_id = $1`,
+				userID,
+			)
+			if err != nil {
+				return nil, status.Error(codes.Internal, "failed to delete the mfa_secrets")
+			}
+
+		default:
+			return nil, status.Error(codes.InvalidArgument, "invalid mfa_type")
+		}
 
 	return &goth.DisableMFAResponse{
 		Success: true,

--- a/internal/handlers/disable_mfa.go
+++ b/internal/handlers/disable_mfa.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"log"
 
 	"github.com/ayush00git/goth/grpc/goth"
 	"github.com/ayush00git/goth/internal/helpers"
@@ -26,10 +27,11 @@ func (g *GothServer) DisableMFA(ctx context.Context, req *goth.DisableMFARequest
 		ctx,
 		`SELECT mfa_type, totp_secret
 		FROM mfa_secrets
-		WHERE id = $1`,
+		WHERE user_id = $1`,
 		userID,
 	).Scan(&initials.MfaType, &initials.TotpSecret)
 	if err != nil {
+		log.Printf("Error: %v", err)
 		return nil, status.Error(codes.Internal, "failed to read the database")
 	}
 

--- a/internal/handlers/verify_mfa.go
+++ b/internal/handlers/verify_mfa.go
@@ -13,7 +13,7 @@ import (
 
 type Creds struct {
 	MfaType		int32
-	TotpSecret	string
+	TotpSecret	*string
 }
 
 // VerifyMFA completes the MFA of client based on its mfa_type and returns
@@ -48,7 +48,7 @@ func (g *GothServer) VerifyMFA(ctx context.Context, req *goth.VerifyMFARequest) 
 		case 1:
 			// validate the client entered TOTP by generating it on server-side
 			// via the same totp_secret.
-			valid := totp.Validate(code, initials.TotpSecret)	// computes the check by the RPC 6238 algorithm
+			valid := totp.Validate(code, *initials.TotpSecret)	// computes the check by the RPC 6238 algorithm
 			if !valid {
 				return nil, status.Error(codes.PermissionDenied, "invalid code")
 			}


### PR DESCRIPTION
This PR implements a `DisableMFA` rpc hanlder for an user. 
Validates the code (totp_secret for the `mfa_type=1` user and otp for the `mfa_type=2` users) and deletes the mfa_secrets field from the `mfa_secrets` table for that user.

Also helps when user wants to change their MFAType -
- Just remove the old MFAType.
- Verify it with proper credentials.
- Set a new one.
- Verify it.
- Again a new `mfa_secrets` table for that user.